### PR TITLE
P07 ci: allow SARIF upload and update upload-sarif to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -15,6 +16,7 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -32,6 +34,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |
@@ -64,7 +69,7 @@ jobs:
         run: |
           docker build -t secdev-study-planner:ci .
 
-      - name: Debug - import httpx in image
+      - name: Debug import httpx in image
         run: |
           docker run --rm secdev-study-planner:ci \
             python -c "import httpx; print('httpx OK', httpx.__version__)"
@@ -78,8 +83,8 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
 
-      - name: Upload Trivy report
-        uses: github/codeql-action/upload-sarif@v3
+      - name: Upload Trivy report (SARIF)
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy.sarif
 
@@ -94,7 +99,6 @@ jobs:
         run: |
           python - <<'PY'
           import time, subprocess, sys
-
           for _ in range(45):
               try:
                   subprocess.check_call([
@@ -105,7 +109,6 @@ jobs:
                   sys.exit(0)
               except Exception:
                   time.sleep(1)
-
           raise SystemExit("Health endpoint did not become ready")
           PY
 


### PR DESCRIPTION
# P07 — Контейнеризация и базовый харднинг (Study Planner)

## Связанная задача
Closes #P07-1  
Closes #P07-2  
Closes #P07-3  

## Что сделано
- Добавлен `Dockerfile` с **multi-stage build** для сервиса Study Planner
- Финальный runtime-образ минимизирован и **не содержит dev-зависимостей**
- Контейнер запускается **под непривилегированным пользователем**
- Добавлен `HEALTHCHECK` для проверки доступности сервиса
- Добавлен `compose.yaml` для локальной сборки и запуска
- В CI добавлены проверки контейнера:
  - линт Dockerfile (hadolint)
  - сканирование образа на уязвимости (Trivy) с сохранением отчёта

## Почему так
Цель задания P07 — обеспечить воспроизводимую и безопасную контейнеризацию сервиса.
Применённый подход позволяет:
- снизить поверхность атаки за счёт non-root execution и минимального образа;
- выявлять уязвимости на ранней стадии через автоматическое сканирование образа;
- упростить локальный запуск и проверку сервиса через docker compose;
- подготовить сервис к дальнейшей интеграции в CI/CD и production-окружение.

## Как проверял
- Локально:
  - `docker compose up --build`
  - `docker compose exec app id -u` (UID ≠ 0)
  - проверка health-endpoint
- В CI:
  - hadolint для Dockerfile
  - trivy scan образа
  - pytest, линтеры и форматтеры

## Артефакты
- `Dockerfile`
- `compose.yaml`
- отчёт hadolint (CI)
- отчёт Trivy (CI artifact)

## Чек-лист перед merge
- [ ] Dockerfile использует multi-stage build
- [ ] Контейнер запускается не под root
- [ ] HEALTHCHECK настроен и работает
- [ ] Есть compose-файл для локального запуска
- [ ] В CI есть линт Dockerfile и сканирование образа
- [ ] CI / build зелёный
- [ ] Все discussion resolved

Reviewer: @DaniilCS
