### PR TITLE
P11: add DAST (ZAP baseline) workflow

### DIFF
--- a/.github/workflows/ci-p11-dast.yml
+++ b/.github/workflows/ci-p11-dast.yml
@@ -1,0 +1,84 @@
+name: Security - DAST (ZAP baseline)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "app/**"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - "Dockerfile"
+      - ".github/workflows/ci-p11-dast.yml"
+  pull_request:
+    paths:
+      - "app/**"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - "Dockerfile"
+      - ".github/workflows/ci-p11-dast.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dast_zap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure evidence dirs
+        run: mkdir -p EVIDENCE/P11
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run app (uvicorn) and wait for health
+        run: |
+          set -euo pipefail
+          uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+          echo $! > /tmp/uvicorn.pid
+
+          # ждём готовность
+          timeout 60 bash -c 'until curl -sf http://localhost:8000/health > /dev/null; do sleep 1; done'
+          echo "App is up: http://localhost:8000/"
+
+      - name: ZAP Baseline scan
+        run: |
+          set -euo pipefail
+
+          docker run --rm --network host \
+            -v "$PWD:/zap/wrk" -w /zap/wrk \
+            owasp/zap2docker-stable \
+            zap-baseline.py \
+              -t http://localhost:8000 \
+              -r zap_baseline.html \
+              -J zap_baseline.json \
+              -d || true
+
+          mv -f zap_baseline.html zap_baseline.json EVIDENCE/P11/ || true
+
+      - name: Stop app
+        if: always()
+        run: |
+          if [ -f /tmp/uvicorn.pid ]; then kill "$(cat /tmp/uvicorn.pid)" || true; fi
+
+      - name: Upload P11 evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: P11_EVIDENCE
+          path: EVIDENCE/P11


### PR DESCRIPTION
В рамках практики **P11** добавлен CI-workflow для минимального DAST-сканирования
курсового HTTP-сервиса с помощью **OWASP ZAP baseline**.

### Target
- URL: `http://localhost:8000/`
- Health-check: `http://localhost:8000/health`

### Что сделано
- Добавлен workflow `.github/workflows/ci-p11-dast.yml`.
- В job поднимается реальный сервис проекта (uvicorn), выполняется ожидание готовности по `/health`,
  затем запускается `zap-baseline.py` против локального URL.

### Отчёты
- `EVIDENCE/P11/zap_baseline.html` — HTML отчёт
- `EVIDENCE/P11/zap_baseline.json` — JSON отчёт
- Также публикуются как артефакты GitHub Actions (`P11_EVIDENCE`).

### Результаты и план
- Result: N alerts (High=X, Medium=Y, Low=Z) — см. отчёты.
- План: triage алертов; для реально значимых — завести задачу и исправить,
  для ложноположительных/информационных — задокументировать причины.