### PR TITLE
P12: add IaC & container security checks

### DIFF
--- a/.github/workflows/ci-p12-iac-container.yml
+++ b/.github/workflows/ci-p12-iac-container.yml
@@ -1,0 +1,94 @@
+name: Security - IaC & Container (P12)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "Dockerfile"
+      - "iac/**"
+      - "k8s/**"
+      - "deploy/**"
+      - "security/**"
+      - ".github/workflows/ci-p12-iac-container.yml"
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "iac/**"
+      - "k8s/**"
+      - "deploy/**"
+      - "security/**"
+      - ".github/workflows/ci-p12-iac-container.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  p12_iac_container:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure evidence dirs
+        run: mkdir -p EVIDENCE/P12
+
+      - name: Build image
+        run: |
+          set -euo pipefail
+          docker build -t app:p12-${{ github.sha }} .
+
+      - name: Hadolint (Dockerfile -> JSON)
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD:/work" \
+            hadolint/hadolint:latest \
+            hadolint -c /work/security/hadolint.yaml -f json /work/Dockerfile \
+            > EVIDENCE/P12/hadolint_report.json || true
+
+      - name: Checkov (IaC dir -> JSON)
+        run: |
+          set -euo pipefail
+
+          # Выбираем первый существующий каталог IaC
+          IAC_DIR=""
+          for d in iac k8s deploy; do
+            if [ -d "$d" ]; then IAC_DIR="$d"; break; fi
+          done
+
+          if [ -z "$IAC_DIR" ]; then
+            echo "No IaC directory found (iac/, k8s/, deploy/). Creating minimal iac/ is recommended."
+            # создадим пустой отчёт, чтобы workflow был зелёным
+            echo '{"error":"No IaC directory found. Create iac/ (e.g., docker-compose.yml or k8s manifests)"}' \
+              > EVIDENCE/P12/checkov_report.json
+            exit 0
+          fi
+
+          docker run --rm -v "$PWD:/work" bridgecrew/checkov:latest \
+            --config-file /work/security/checkov.yaml \
+            -d "/work/${IAC_DIR}" \
+            -o json > EVIDENCE/P12/checkov_report.json || true
+
+      - name: Trivy (image -> JSON)
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$PWD:/work" \
+            aquasec/trivy:latest \
+            image app:p12-${{ github.sha }} \
+              --format json \
+              --output /work/EVIDENCE/P12/trivy_report.json || true
+
+      - name: Upload P12 evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: P12_EVIDENCE
+          path: EVIDENCE/P12

--- a/iac/compose.yaml
+++ b/iac/compose.yaml
@@ -1,0 +1,32 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: secdev-study-planner:local
+    ports:
+      - "8000:8000"
+    environment:
+      - RATE_LIMIT_MAX=60
+      - RATE_LIMIT_WINDOW_SECONDS=60
+      - UPLOAD_DIR=/app/uploads
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2).read()"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      - uploads:/app/uploads
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 200
+
+volumes:
+  uploads:

--- a/security/checkov.yaml
+++ b/security/checkov.yaml
@@ -1,0 +1,5 @@
+# security/checkov.yaml
+quiet: false
+compact: true
+
+skip-check: []

--- a/security/hadolint.yaml
+++ b/security/hadolint.yaml
@@ -1,0 +1,2 @@
+# security/hadolint.yaml
+ignored: []

--- a/security/trivy.yaml
+++ b/security/trivy.yaml
@@ -1,0 +1,8 @@
+# security/trivy.yaml
+scan:
+  scanners:
+    - vuln
+  severity:
+    - CRITICAL
+    - HIGH
+format: "json"


### PR DESCRIPTION
В рамках практики **P12** добавлен CI-workflow для проверки Dockerfile, IaC и контейнерного образа.

### Что сделано
- Добавлен workflow `.github/workflows/ci-p12-iac-container.yml`.
- Hadolint проверяет `Dockerfile` с конфигом `security/hadolint.yaml` и сохраняет отчёт в JSON.
- Checkov сканирует IaC-каталог (`iac/` / `k8s/` / `deploy/`) с конфигом `security/checkov.yaml` и сохраняет отчёт в JSON.
- Trivy сканирует собранный образ `app:p12-<sha>` и сохраняет отчёт в JSON.
- Все отчёты также публикуются как артефакты GitHub Actions (`P12_EVIDENCE`).

### Артефакты
- `EVIDENCE/P12/hadolint_report.json`
- `EVIDENCE/P12/checkov_report.json`
- `EVIDENCE/P12/trivy_report.json`

### Hardening (что уже сделано / план)
- Dockerfile: (например) избегаем `:latest`, планируем/используем фиксированный base image; (опционально) запуск non-root.
- IaC: минимальная инфраструктура вынесена в `iac/` (или существующие `k8s/`/`deploy/`), дальше — триаж findings Checkov.
- По Trivy: triage High/Critical → обновить base image/пакеты или задокументировать, почему неактуально.

